### PR TITLE
Remove httpcore5-h2 exclusion

### DIFF
--- a/docker-java-transport-httpclient5/pom.xml
+++ b/docker-java-transport-httpclient5/pom.xml
@@ -30,12 +30,6 @@
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
 			<version>5.0.3</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.httpcomponents.core5</groupId>
-					<artifactId>httpcore5-h2</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Exclusion was added 3 years ago - not sure why.
But this transitive dependency is needed https://github.com/docker-java/docker-java/issues/2183
